### PR TITLE
Asg 7 update op code create tests with corrected cbusdefs

### DIFF
--- a/Asgard.Tests/OpCodeCreateTests.cs
+++ b/Asgard.Tests/OpCodeCreateTests.cs
@@ -864,8 +864,7 @@ namespace Asgard.Tests
 		}
 
 		[Test]
-		[Ignore("Incorrect name in cbusdefs")]
-		public void CreateBOOTTest() // 0x5C 92
+		public void CreateBOOTMTest() // 0x5C 92
 		{
 			var data = new byte[]
 			{
@@ -880,7 +879,7 @@ namespace Asgard.Tests
             Assert.Multiple(() =>
             {
                 Assert.That(opcode, Is.Not.Null);
-                Assert.That(opcode?.GetType().Name, Is.EqualTo("BOOT"));
+                Assert.That(opcode?.GetType().Name, Is.EqualTo("BOOTM"));
             });
 		}
 

--- a/Asgard.Tests/OpCodeCreateTests.tt
+++ b/Asgard.Tests/OpCodeCreateTests.tt
@@ -12,7 +12,6 @@
 	var ignores =
 		new Dictionary<string, string>
 		{
-			["BOOT"]   = "Incorrect name in cbusdefs",
 			["CABDAT"] = "Not in version 6b",
 			["DDWS"]   = "Not in version 6b",
 			["DTXC"]   = "Not in version 6b",

--- a/Asgard.Tests/cbusdefs.csv
+++ b/Asgard.Tests/cbusdefs.csv
@@ -78,6 +78,7 @@ comment,,,Pete Brownlow,06/09/20,Ver 8t Added module type for CANRCOM. Fixed: Op
 comment,,,Andrew Crosland,21/09/21,Ver 8t Added PICs P18F14K22 P18F26K83 P18F27Q84 P18F47Q84 and P18F27Q83
 comment,,,Duncan Greenwood,07/10/21,Ver 8t Added OPC_DTXC opcode (0xE9) for CBUS long messages
 comment,,,Richard Crawshaw,11/10/2021,Ver 8t Fixed trailing comma in CbusCabSigAspect0
+comment,,,Richard Crawshaw,11/12/2021,Ver 8t Corrected BOOTM OpCode (was incorrectly BOOT) see https://www.merg.org.uk/forum/viewtopic.php?p=161100#p161067
 comment,,,
 CbusManufacturer,,,CBUS Manufacturer definitions
 CbusManufacturer,,,Where the manufacturer already has an NMRA code, this is used
@@ -243,7 +244,7 @@ CbusOpCodes,OPC_RQEVN,0x58,Read number of stored events
 CbusOpCodes,OPC_WRACK,0x59,Write acknowledge
 CbusOpCodes,OPC_RQDAT,0x5A,Request node data event
 CbusOpCodes,OPC_RQDDS,0x5B,Request short data frame
-CbusOpCodes,OPC_BOOT,0x5C,Put node into boot mode
+CbusOpCodes,OPC_BOOTM,0x5C,Put node into boot mode
 CbusOpCodes,OPC_ENUM,0x5D,Force can_id self enumeration
 CbusOpCodes,OPC_NNRST,0x5E,Reset node (as in restart)
 CbusOpCodes,OPC_EXTC1,0x5F,Extended opcode with 1 data byte

--- a/Asgard/Communications/Classes/CbusCanFrame.cs
+++ b/Asgard/Communications/Classes/CbusCanFrame.cs
@@ -12,33 +12,32 @@ namespace Asgard.Communications
         public byte SidH { get; set; }
         public byte SidL { get; set; }
         public FrameTypes FrameType { get; set; }
+
         public MajorPriority MajorPriority
         {
-            get => (MajorPriority)(SidH >> 6);
-            set => SidH = (byte)(((byte)value << 6) + (SidH & 0x3f));
+            get => (MajorPriority)(this.SidH >> 6);
+            set => this.SidH = (byte)(((byte)value << 6) + (this.SidH & 0x3f));
         }
 
         public MinorPriority MinorPriority
         {
-            get => (MinorPriority)(SidH >> 4 & 0x3);
-            set => SidH = (byte)(((byte)value << 4) + (SidH & 0xcf));
+            get => (MinorPriority)(this.SidH >> 4 & 0x3);
+            set => this.SidH = (byte)(((byte)value << 4) + (this.SidH & 0xcf));
         }
 
         public byte CanId
         {
-            get => (byte)((SidH << 8) + SidL >> 5 & 0x7f);
+            get => (byte)((this.SidH << 8) + this.SidL >> 5 & 0x7f);
             set
             {
-                SidH = (byte)((value >> 3) + (SidH & 0xF0));
-                SidL = (byte)(value << 5 & 0xFF);
+                this.SidH = (byte)((value >> 3) + (this.SidH & 0xF0));
+                this.SidL = (byte)(value << 5 & 0xFF);
             }
         }
+
         public ICbusMessage Message { get; set; }
 
-        public override string ToString()
-        {
-            //TODO: construct a reasonable looking frame representation for logging purposes
-            return base.ToString();
-        }
+        public override string ToString() => 
+            $"0x{this.SidL:X2} 0x{this.SidH:X2} (0x{this.CanId:X2}) {this.FrameType} {this.Message}";
     }
 }

--- a/Asgard/Public/Settings.cs
+++ b/Asgard/Public/Settings.cs
@@ -11,7 +11,7 @@ namespace Asgard
     {
         #region Fields
 
-        private IList<ISettings.ISettingsNode> settingsNodes = new List<ISettings.ISettingsNode>();
+        private readonly IList<ISettings.ISettingsNode> settingsNodes = new List<ISettings.ISettingsNode>();
 
         #endregion
 


### PR DESCRIPTION
cbusdefs had an incorrect opcode for BOOT (should have been BOOTM). This has been corrected and a PR submitted; currently awaiting merge. This has allowed the OpCode creation test for BOOTM to be reinstated.