### PR TITLE
Marking opcodes as replies

### DIFF
--- a/Asgard.ExampleUse/ExampleUse.cs
+++ b/Asgard.ExampleUse/ExampleUse.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Asgard.Communications;
 using Asgard.Data;
@@ -32,8 +33,9 @@ namespace Asgard.ExampleUse
             try
             {
                 await this.cbusMessenger.OpenAsync();
-
                 var mm = new MessageManager(this.cbusMessenger);
+
+                //Send and receive replies by specifying what you're expecting in response to a request
                 this.logger.LogInformation("Sending node query");
                 var replies = await mm.SendMessageWaitForReplies<ResponseToQueryNode>(new QueryNodeNumber());
                 foreach(var reply in replies)
@@ -41,6 +43,27 @@ namespace Asgard.ExampleUse
                     this.logger.LogInformation(
                         $"Node info: Node number: {reply.NodeNumber}, ModuleID: {reply.ModuleId}");
                 }
+
+                
+                //Send and receive replies using built-in Asgard response filtering
+                var response = await mm.SendMessageWaitForReply(new GetEngineSession());
+                switch (response)
+                {
+                    case ResponseToQueryNode report:
+                        //do stuff
+                        break;
+                    case CommandStationErrorReport error:
+                        //do other stuff
+                        break;
+                }
+                if (response is IErrorReplyTo<GetEngineSession>)
+                {
+                    //Do stuff if it was a en error reply without knowing specific response type as above
+                }
+
+
+
+
             }
             catch (TransportException e)
             {

--- a/Asgard.Tests/CommunicationTests/MessageManagerTests.cs
+++ b/Asgard.Tests/CommunicationTests/MessageManagerTests.cs
@@ -86,5 +86,39 @@ namespace Asgard.Tests.CommunicationTests
                 mm.SendMessageWaitForReplies<ResponseToQueryNode>(
                     new QueryNodeNumber(), 2));
         }
+
+        [Test]
+        public async Task Manager_ReturnsCorrectMessages_WhenMultipleRequestsAreInFlight()
+        {
+            var messenger = new Mock<ICbusMessenger>();
+            var mm = new MessageManager(messenger.Object);
+
+            var responseTask1 = mm.SendMessageWaitForReply(new GetEngineSession() { Address = 10 });
+            var responseTask2 = mm.SendMessageWaitForReply(new GetEngineSession() { Address = 20 });
+            var responseTask3 = mm.SendMessageWaitForReply(new GetEngineSession() { Address = 30 });
+
+
+            messenger.Raise(m => m.MessageReceived += null, new CbusMessageEventArgs(new EngineReport() { Address = 20 }.Message));
+            messenger.Raise(m => m.MessageReceived += null, new CbusMessageEventArgs(new EngineReport() { Address = 10 }.Message));
+            messenger.Raise(m => m.MessageReceived += null, new CbusMessageEventArgs(new CommandStationErrorReport() { Data1 = 0, Data2 = 30 }.Message));
+
+            var response1 = await responseTask1;
+            var response2 = await responseTask2;
+            var response3 = await responseTask3;
+
+            response1.Should().BeOfType<EngineReport>();
+            response2.Should().BeOfType<EngineReport>();
+            response3.Should().BeOfType<CommandStationErrorReport>();
+
+            var r1 = (EngineReport)response1;
+            var r2 = (EngineReport)response2;
+            var r3 = (CommandStationErrorReport)response3;
+
+            r1.Address.Should().Be(10);
+            r2.Address.Should().Be(20);
+            r3.Data2.Should().Be(30);
+        }
+
+
     }
 }

--- a/Asgard/Communications/Classes/MessageManager.cs
+++ b/Asgard/Communications/Classes/MessageManager.cs
@@ -29,8 +29,8 @@ namespace Asgard.Communications
         /// <param name="msg">The message to send.</param>
         /// <param name="filterResponse">An optional filter callback to further process the replies to ensure you get the right one.</param>
         /// <returns>The first message of the given type that passes the filterResponse.</returns>
-        public Task<T> SendMessageWaitForReply<T>(ICbusOpCode msg, Func<T, bool> filterResponse = null) 
-            where T:ICbusOpCode => SendMessageWaitForReply(msg, DefaultTimeout, filterResponse);
+        public Task<T> SendMessageWaitForReply<T>(ICbusOpCode msg, Func<T, bool> filterResponse = null)
+            where T : ICbusOpCode => SendMessageWaitForReply(msg, DefaultTimeout, filterResponse);
 
         /// <summary>
         /// Sends a message and awaits a given reply, or times out.
@@ -40,8 +40,8 @@ namespace Asgard.Communications
         /// <param name="timeout">The amount of time to wait for a response.</param>
         /// <param name="filterResponse">An optional filter callback to further process the replies to ensure you get the right one.</param>
         /// <returns>The first message of the given type that passes the filterResponse.</returns>
-        public async Task<T> SendMessageWaitForReply<T>(ICbusOpCode msg, TimeSpan timeout, Func<T, bool> filterResponse = null) 
-            where T:ICbusOpCode => (await SendMessageWaitForReplies(msg, timeout, 1, filterResponse)).First();
+        public async Task<T> SendMessageWaitForReply<T>(ICbusOpCode msg, TimeSpan timeout, Func<T, bool> filterResponse = null)
+            where T : ICbusOpCode => (await SendMessageWaitForReplies(msg, timeout, 1, filterResponse)).First();
 
         /// <summary>
         /// Sends a message and waits for replies, or times out.
@@ -51,8 +51,47 @@ namespace Asgard.Communications
         /// <param name="expected">The number of expected responses. Times out if this number is not received. Specify 0 for an unknown number of responses. Returns immediately when this number of responses have been received.</param>
         /// <param name="filterResponses">An optional filter callback to further process the replies to ensure you get the right ones.</param>
         /// <returns>The received responses.</returns>
-        public Task<IEnumerable<T>> SendMessageWaitForReplies<T>(ICbusOpCode msg, int expected = 0, Func<T, bool> filterResponses = null) 
-            where T:ICbusOpCode => SendMessageWaitForReplies(msg, DefaultTimeout, expected, filterResponses);
+        public Task<IEnumerable<T>> SendMessageWaitForReplies<T>(ICbusOpCode msg, int expected = 0, Func<T, bool> filterResponses = null)
+            where T : ICbusOpCode => SendMessageWaitForReplies(msg, DefaultTimeout, expected, filterResponses);
+
+        /// <summary>
+        /// Sends a message and awaits a given reply, or times out.
+        /// </summary>
+        /// <typeparam name="T">The type of message to send, and use Asgard to filter and return known reply messages for.</typeparam>
+        /// <param name="msg">The message to send.</param>
+        public async Task<IReplyTo<T>> SendMessageWaitForReply<T>(T msg)
+            where T : ICbusOpCode => (await SendMessageWaitForReplies<T>(msg, DefaultTimeout, 1)).First();
+
+        /// <summary>
+        /// Sends a message and awaits a given reply, or times out.
+        /// </summary>
+        /// <typeparam name="T">The type of message to send, and use Asgard to filter and return known reply messages for.</typeparam>
+        /// <param name="msg">The message to send.</param>
+        /// <param name="timeout">The amount of time to wait for a response.</param>
+        public async Task<IReplyTo<T>> SendMessageWaitForReply<T>(T msg, TimeSpan timeout)
+            where T : ICbusOpCode => (await SendMessageWaitForReplies<T>(msg, timeout, 1)).First();
+
+        /// <summary>
+        /// Send a message and waits for replies, or times out.
+        /// </summary>
+        /// <typeparam name="T">The type of message to send, and use Asgard to filter and return known reply messages for.</typeparam>
+        /// <param name="message">The message to send.</param>
+        /// <param name="expected">The number of expected responses. Times out if this number is not received. Specify 0 for an unknown number of responses. Returns immediately when this number of responses have been received.</param>
+        /// <returns>The received responses.</returns>
+        public Task<IEnumerable<IReplyTo<T>>> SendMessageWaitForReplies<T>(T message, int expected = 0) where T : ICbusOpCode =>
+            SendMessageWaitForReplies(message, DefaultTimeout, expected);
+
+        /// <summary>
+        /// Send a message and waits for replies, or times out.
+        /// </summary>
+        /// <typeparam name="T">The type of message to send, and use Asgard to filter and return known reply messages for.</typeparam>
+        /// <param name="message">The message to send.</param>
+        /// <param name="timeout">The amount of time to wait for a response.</param>
+        /// <param name="expected">The number of expected responses. Times out if this number is not received. Specify 0 for an unknown number of responses. Returns immediately when this number of responses have been received.</param>
+        /// <returns>The received responses.</returns>
+        public Task<IEnumerable<IReplyTo<T>>> SendMessageWaitForReplies<T>(T message, TimeSpan timeout, int expected = 0)
+            where T : ICbusOpCode =>
+            SendMessageWaitForReplies<IReplyTo<T>>(message, expected, (r) => r.IsReply(message));
 
         /// <summary>
         /// Sends a message and waits for replies, or times out.
@@ -63,9 +102,9 @@ namespace Asgard.Communications
         /// <param name="expected">The number of expected responses. Times out if this number is not received. Specify 0 for an unknown number of responses. Returns immediately when this number of responses have been received.</param>
         /// <param name="filterResponses">An optional filter callback to further process the replies to ensure you get the right ones.</param>
         /// <returns>The received responses.</returns>
-        public async Task<IEnumerable<T>> SendMessageWaitForReplies<T>(ICbusOpCode msg, TimeSpan timeout, int expected = 0, Func<T, bool> filterResponses = null) where T:ICbusOpCode
+        public async Task<IEnumerable<T>> SendMessageWaitForReplies<T>(ICbusOpCode msg, TimeSpan timeout, int expected = 0, Func<T, bool> filterResponses = null) where T : ICbusOpCode
         {
-            this.logger?.LogTrace($"Sending message of type {0}, awaiting {1} replies with a timeout of {2}", 
+            this.logger?.LogTrace($"Sending message of type {0}, awaiting {1} replies with a timeout of {2}",
                 msg.GetType().Name, typeof(T).Name, expected);
 
             var tcs = new TaskCompletionSource<bool>();

--- a/Asgard/Data/Interfaces/IReplyTo.cs
+++ b/Asgard/Data/Interfaces/IReplyTo.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Asgard.Data
+{
+    /// <summary>
+    /// Applied to OpCodes to indicate that they may be sent in response to specific request messages.
+    /// </summary>
+    /// <typeparam name="T">The type of request message that this may be a response to.</typeparam>
+    public interface IReplyTo<T>:ICbusOpCode where T:ICbusOpCode {
+        /// <summary>
+        /// Called automatically to check if this particular response is for a specific request.
+        /// </summary>
+        /// <param name="request">The request that this response should be checked against.</param>
+        /// <returns>Should return true if this is a matching response to the supplied, otherwise false."/></returns>
+        bool IsReply(T request);
+    }
+
+    /// <summary>
+    /// Applied to OpCodes to indicate that they may be sent as an error response to specific request messages.
+    /// </summary>
+    /// <typeparam name="T">The type of request message that this may be a response to.</typeparam>
+    public interface IErrorReplyTo<T> : IReplyTo<T> where T : ICbusOpCode { }
+}

--- a/Asgard/Data/Partial/CommandStationErrorReport.cs
+++ b/Asgard/Data/Partial/CommandStationErrorReport.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Asgard.Data
+{
+    public partial class CommandStationErrorReport : IErrorReplyTo<GetEngineSession>
+    {
+        public bool IsReply(GetEngineSession request)
+        {
+            var address = (ushort)(
+                (this.Data1 << 08) +
+                this.Data2);
+
+            return address == request.Address;
+        }
+    }
+}

--- a/Asgard/Data/Partial/EngineReport.cs
+++ b/Asgard/Data/Partial/EngineReport.cs
@@ -1,0 +1,7 @@
+﻿namespace Asgard.Data
+{
+    public partial class EngineReport : IReplyTo<GetEngineSession>
+    {
+        public bool IsReply(GetEngineSession request) => this.Address == request.Address;
+    }
+}

--- a/Asgard/Data/Partial/ReadNodeParameter.cs
+++ b/Asgard/Data/Partial/ReadNodeParameter.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Asgard.Data
+{
+    public partial class ResponseToRequestForIndividualNodeParameter : IReplyTo<RequestReadOfANodeParameterByIndex>
+    {
+        public bool IsReply(RequestReadOfANodeParameterByIndex request) =>
+            request.NodeNumber == this.NodeNumber && request.ParamIndex == this.ParamIndex;
+    }
+}


### PR DESCRIPTION
Added `IReplyTo<T>` and `IErrorReplyTo<T>` to allow marking of certain messages as being potential replies to others.  These interfaces then allow those messages to work out themselves whether they are actually replies or not, and extra overloads have been added to `MessageManager` to use this built in filters.

Users of the library can skip this functionality and continue to supply their own filtering functions if they wish to decide what is and isn't a true reply themselves.