### PR TITLE
Fix issue with CAN frame creation on message sending after nullable refactor

### DIFF
--- a/Asgard/Communications/Classes/CbusCanFrame.cs
+++ b/Asgard/Communications/Classes/CbusCanFrame.cs
@@ -42,12 +42,13 @@ namespace Asgard.Communications
                             ILogger<CbusCanFrame>? logger = null)
         {
             this.Message = message;
+            Instantiate(this.Message.GetOpCode());
 
             this.settings = settings;
             this.logger = logger;
         }
 
-        public void Instantiate(ICbusOpCode? cbusOpCode)
+        private void Instantiate(ICbusOpCode? cbusOpCode)
         {
             // TODO: Extract the major and minor priority from the op-code meta-data.
 

--- a/Asgard/Communications/Classes/CbusCanFrame.cs
+++ b/Asgard/Communications/Classes/CbusCanFrame.cs
@@ -48,7 +48,7 @@ namespace Asgard.Communications
             this.logger = logger;
         }
 
-        private void Instantiate(ICbusOpCode? cbusOpCode)
+        private void Instantiate(ICbusOpCode cbusOpCode)
         {
             // TODO: Extract the major and minor priority from the op-code meta-data.
 
@@ -56,7 +56,7 @@ namespace Asgard.Communications
             this.MajorPriority = this.settings?.GetMajorPriority() ?? MajorPriority.Low;
             this.MinorPriority = this.settings?.GetMinorPriority() ?? MinorPriority.Normal;
 
-            this.logger?.LogInformation($"Created CAN frame for {cbusOpCode?.Code}");
+            this.logger?.LogInformation($"Created CAN frame for {cbusOpCode.Code}");
         }
 
         public override string ToString() => 

--- a/Asgard/Communications/Classes/CbusCanFrameFactory.cs
+++ b/Asgard/Communications/Classes/CbusCanFrameFactory.cs
@@ -33,9 +33,7 @@ namespace Asgard.Communications
 
             var result =
                 ActivatorUtilities.CreateInstance<CbusCanFrame>(
-                    this.services, new[] { frame, });
-            result.Instantiate(message.GetOpCode());
-            result.Message = message;
+                    this.services, new object[] { frame, message });
             return result;
         }
     }


### PR DESCRIPTION
Pass message into DI creation process in the CAN frame factory. Refactor frame header property setting internally now it has the message passed in anyway.